### PR TITLE
Don't re-install Akeneo once installed

### DIFF
--- a/init-akeneo.sh
+++ b/init-akeneo.sh
@@ -2,10 +2,15 @@
 set -e
 
 cd /var/www/pim-community-standard-v1.3.2-icecat
-sed -i 's/localhost/'$LINK_ALIAS'/' app/config/parameters.yml
-php app/console cache:clear --env=prod
-php app/console pim:install --env=prod
-chown -R www-data:www-data /var/www
+
+if [ ! -f installed ]; then
+    echo "Installing Akeneo for first boot"
+    sed -i 's/localhost/'$LINK_ALIAS'/' app/config/parameters.yml
+    php app/console cache:clear --env=prod
+    php app/console pim:install --env=prod
+    chown -R www-data:www-data /var/www
+    echo "" > installed
+fi
 
 apache2ctl -D FOREGROUND
 


### PR DESCRIPTION
Hi, and thanks for publishing your Akeneo image!

I had an issue where it would try to re-install Akeneo every time I restarted the image with docker-compose. I don't know if I might have misunderstood something, or if this might have been intended?

Anyway, I wanted to share my solution.

In `init-akeneo.sh`, create an empty file named `installed` after Akeneo is
installed. Look for this file on future runs to determine wheter or not the
system is already installed, in which case, install should be bypassed.

